### PR TITLE
Prevent empty links

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,12 @@ An array of contributors, with properties such as:
 
 ## Contributors
 
-| Name             | GitHub                                              | Twitter                                               |
-| ---------------- | --------------------------------------------------- | ----------------------------------------------------- |
-| **Hugh Kennedy** | [**@hughsk**](https://github.com/hughsk)             | [**@hughskennedy**](https://twitter.com/hughskennedy) |
-| **Titus Wormer** | [**@wooorm**](https://github.com/wooorm)             | [**@wooorm**](https://twitter.com/wooorm)             |
-| **Nick Baugh**   | [**@niftylettuce**](https://github.com/niftylettuce) | [**@niftylettuce**](https://twitter.com/niftylettuce) |
+| Name                | GitHub                                               | Twitter                                               |
+| ------------------- | ---------------------------------------------------- | ----------------------------------------------------- |
+| **Hugh Kennedy**    | [**@hughsk**](https://github.com/hughsk)             | [**@hughskennedy**](https://twitter.com/hughskennedy) |
+| **Titus Wormer**    | [**@wooorm**](https://github.com/wooorm)             | [**@wooorm**](https://twitter.com/wooorm)             |
+| **Nick Baugh**      | [**@niftylettuce**](https://github.com/niftylettuce) | [**@niftylettuce**](https://twitter.com/niftylettuce) |
+| **Vincent Weevers** | [**@vweevers**](https://github.com/vweevers)         | [**@vweevers**](https://twitter.com/vweevers)         |
 
 ## License
 

--- a/fixtures/partial-expected.md
+++ b/fixtures/partial-expected.md
@@ -1,0 +1,11 @@
+# Partial Fixture
+
+This document has no contributors table in here yet.
+
+## Contributors
+
+| Name      | GitHub                               | Twitter                                 |
+| --------- | ------------------------------------ | --------------------------------------- |
+| **Sara**  | [**@sara**](https://github.com/sara) |                                         |
+| **Jason** |                                      |                                         |
+| **Alice** |                                      | [**@alice**](https://twitter.com/alice) |

--- a/fixtures/partial.md
+++ b/fixtures/partial.md
@@ -1,0 +1,3 @@
+# Partial Fixture
+
+This document has no contributors table in here yet.

--- a/index.js
+++ b/index.js
@@ -160,26 +160,31 @@ function contributorTableAttacher(opts) {
             value = value.substring(1);
           }
 
-          // Ensure https link is used and properly formatted username
-          child.type = 'link';
-          child.url = 'https://' + key + '.com/' + value;
+          // Prevent empty links
+          if (value === '') {
+            child.value = '';
+          } else {
+            // Ensure https link is used and properly formatted username
+            child.type = 'link';
+            child.url = 'https://' + key + '.com/' + value;
 
-          // Add the "@" prefix to username
-          value = '@' + value;
+            // Add the "@" prefix to username
+            value = '@' + value;
 
-          // TODO: Should we add title here?
-          // Add title
-          // child.title = 'View ' + value + ' on ' + header;
+            // TODO: Should we add title here?
+            // Add title
+            // child.title = 'View ' + value + ' on ' + header;
 
-          child.children = [
-            {
-              // Set the @mention to bold just like GitHub/Twitter do
-              // Note that this package also puts in bold the @mentions
-              // <https://github.com/wooorm/remark-github>
-              type: 'strong',
-              children: [{type: 'text', value}]
-            }
-          ];
+            child.children = [
+              {
+                // Set the @mention to bold just like GitHub/Twitter do
+                // Note that this package also puts in bold the @mentions
+                // <https://github.com/wooorm/remark-github>
+                type: 'strong',
+                children: [{type: 'text', value}]
+              }
+            ];
+          }
         } else if (isURL(value)) {
           child.type = 'link';
           child.url = value;

--- a/inject.js
+++ b/inject.js
@@ -8,7 +8,9 @@ const plugin = require('./')
 fs.writeFileSync('README.md', remark().use(plugin, {
   contributors: [
     { name: 'Hugh Kennedy', github: 'hughsk', twitter: 'hughskennedy' },
-    { name: 'Titus Wormer', github: 'wooorm', twitter: 'wooorm' }
+    { name: 'Titus Wormer', github: 'wooorm', twitter: 'wooorm' },
+    { name: 'Nick Baugh', github: 'niftylettuce', twitter: 'niftylettuce' },
+    { name: 'Vincent Weevers', github: 'vweevers', twitter: 'vweevers' }
   ]
 }).processSync(
   fs.readFileSync('README.md', 'utf8')

--- a/test.js
+++ b/test.js
@@ -22,6 +22,9 @@ const packageExpected = fs.readFileSync('fixtures/package-expected.md', 'utf8');
 const customFixture = fs.readFileSync('fixtures/custom.md', 'utf8');
 const customExpected = fs.readFileSync('fixtures/custom-expected.md', 'utf8');
 
+const partialFixture = fs.readFileSync('fixtures/partial.md', 'utf8');
+const partialExpected = fs.readFileSync('fixtures/partial-expected.md', 'utf8');
+
 test('remark-contributors with package.json contributors field', t => {
   const processor = remark().use(plugin);
   const actual = processor.processSync(packageFixture).toString().trim();
@@ -69,5 +72,22 @@ test('remark-contributors with github/twitter contributors options (with typos)'
     }
   });
 
+  t.end();
+});
+
+test('remark-contributors with partial github/twitter contributors options', t => {
+  const processor = remark().use(plugin, {
+    contributors: [
+      { name: 'Sara', github: 'sara' },
+      { name: 'Jason' },
+      { name: 'Alice', twitter: 'alice' }
+    ]
+  });
+  const actual = processor.processSync(partialFixture).toString().trim();
+  const expect = partialExpected.trim();
+  t.equal(actual, expect, 'Skips missing properties');
+  if (actual !== expect) {
+    console.error(diff.diffChars(expect, actual));
+  }
   t.end();
 });


### PR DESCRIPTION
If a `twitter` or `github` property was missing, it would show up as `[**@**](https://github.com/)`.

Also added @niftylettuce to the contributors (was in the readme table, but not in `inject.js`).