### PR TITLE
Support custom formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,12 @@ An array of contributors, with properties such as:
 
 ## Contributors
 
-| Name             | GitHub                                              | Twitter                                               |
-| ---------------- | --------------------------------------------------- | ----------------------------------------------------- |
-| **Hugh Kennedy** | [**@hughsk**](https://github.com/hughsk)             | [**@hughskennedy**](https://twitter.com/hughskennedy) |
-| **Titus Wormer** | [**@wooorm**](https://github.com/wooorm)             | [**@wooorm**](https://twitter.com/wooorm)             |
-| **Nick Baugh**   | [**@niftylettuce**](https://github.com/niftylettuce) | [**@niftylettuce**](https://twitter.com/niftylettuce) |
+| Name                | GitHub                                               | Twitter                                               |
+| ------------------- | ---------------------------------------------------- | ----------------------------------------------------- |
+| **Hugh Kennedy**    | [**@hughsk**](https://github.com/hughsk)             | [**@hughskennedy**](https://twitter.com/hughskennedy) |
+| **Titus Wormer**    | [**@wooorm**](https://github.com/wooorm)             | [**@wooorm**](https://twitter.com/wooorm)             |
+| **Nick Baugh**      | [**@niftylettuce**](https://github.com/niftylettuce) | [**@niftylettuce**](https://twitter.com/niftylettuce) |
+| **Vincent Weevers** | [**@vweevers**](https://github.com/vweevers)         | [**@vweevers**](https://twitter.com/vweevers)         |
 
 ## License
 

--- a/fixtures/format-expected.md
+++ b/fixtures/format-expected.md
@@ -1,0 +1,11 @@
+# Format Fixture
+
+This document has no contributors table in here yet.
+
+## Contributors
+
+| Name      | GitHub                               | Social         |
+| --------- | ------------------------------------ | -------------- |
+| **Sara**  | [**@sara**](https://github.com/sara) | @sara@domain   |
+| **Jason** |                                      |                |
+| **Alice** |                                      | @alice@twitter |

--- a/fixtures/format.md
+++ b/fixtures/format.md
@@ -1,0 +1,3 @@
+# Format Fixture
+
+This document has no contributors table in here yet.

--- a/fixtures/partial-expected.md
+++ b/fixtures/partial-expected.md
@@ -1,0 +1,11 @@
+# Partial Fixture
+
+This document has no contributors table in here yet.
+
+## Contributors
+
+| Name      | GitHub                               | Twitter                                 |
+| --------- | ------------------------------------ | --------------------------------------- |
+| **Sara**  | [**@sara**](https://github.com/sara) |                                         |
+| **Jason** |                                      |                                         |
+| **Alice** |                                      | [**@alice**](https://twitter.com/alice) |

--- a/fixtures/partial.md
+++ b/fixtures/partial.md
@@ -1,0 +1,3 @@
+# Partial Fixture
+
+This document has no contributors table in here yet.

--- a/headers.js
+++ b/headers.js
@@ -1,5 +1,9 @@
 'use strict'
 
+exports.email = {
+  exclude: true
+};
+
 exports.name = {
   label: 'Name',
   format: function(value) {

--- a/headers.js
+++ b/headers.js
@@ -1,0 +1,73 @@
+'use strict'
+
+exports.name = {
+  label: 'Name',
+  format: function(value) {
+    return {type: 'strong', children: [{type: 'text', value}]};
+  }
+};
+
+exports.url = {
+  label: 'Website'
+};
+
+exports.github = {
+  label: 'GitHub',
+  format: profile
+};
+
+exports.twitter = {
+  label: 'Twitter',
+  format: profile
+};
+
+function profile(value) {
+  const child = {type: 'text'};
+
+  // Automatically strip URL's in values from GitHub and Twitter
+  // So we can display just the username alone
+  const com = '.com/';
+  if (value.toLowerCase().indexOf(com) !== -1) {
+    value = value.substring(value.indexOf(com) + com.length);
+  }
+
+  // Strip out the string without trailing slash if it has one
+  // so we just get the username back from the value entered
+  if (value.indexOf('/') !== -1) {
+    value = value.substring(0, value.indexOf('/'));
+  }
+
+  // Remove "@" from the URL's if there are any
+  if (value.indexOf('@') === 0) {
+    value = value.substring(1);
+  }
+
+  // Prevent empty links
+  if (value === '') {
+    child.value = '';
+    return child;
+  }
+
+  // Ensure https link is used and properly formatted username
+  child.type = 'link';
+  child.url = 'https://' + key + '.com/' + value;
+
+  // Add the "@" prefix to username
+  value = '@' + value;
+
+  // TODO: Should we add title here?
+  // Add title
+  // child.title = 'View ' + value + ' on ' + header;
+
+  child.children = [
+    {
+      // Set the @mention to bold just like GitHub/Twitter do
+      // Note that this package also puts in bold the @mentions
+      // <https://github.com/wooorm/remark-github>
+      type: 'strong',
+      children: [{type: 'text', value}]
+    }
+  ];
+
+  return child;
+}

--- a/index.js
+++ b/index.js
@@ -52,8 +52,7 @@ function contributorTableAttacher(opts) {
       Object.keys(contrib).forEach(original => {
         const key = original.toLowerCase();
 
-        // Exclude email
-        if (key === 'email') {
+        if (headers[key] && headers[key].exclude) {
           return;
         }
 
@@ -80,9 +79,9 @@ function contributorTableAttacher(opts) {
           contrib[key] = value;
         }
 
-        // Never include an email in the table
-        if (key === 'email') {
+        if (headers[key] && headers[key].exclude) {
           delete contrib[key];
+          return;
         }
 
         // Ensure that url => website

--- a/index.js
+++ b/index.js
@@ -160,26 +160,31 @@ function contributorTableAttacher(opts) {
             value = value.substring(1);
           }
 
-          // Ensure https link is used and properly formatted username
-          child.type = 'link';
-          child.url = 'https://' + key + '.com/' + value;
+          // Prevent empty links
+          if (value === '') {
+            child.value = '';
+          } else {
+            // Ensure https link is used and properly formatted username
+            child.type = 'link';
+            child.url = 'https://' + key + '.com/' + value;
 
-          // Add the "@" prefix to username
-          value = '@' + value;
+            // Add the "@" prefix to username
+            value = '@' + value;
 
-          // TODO: Should we add title here?
-          // Add title
-          // child.title = 'View ' + value + ' on ' + header;
+            // TODO: Should we add title here?
+            // Add title
+            // child.title = 'View ' + value + ' on ' + header;
 
-          child.children = [
-            {
-              // Set the @mention to bold just like GitHub/Twitter do
-              // Note that this package also puts in bold the @mentions
-              // <https://github.com/wooorm/remark-github>
-              type: 'strong',
-              children: [{type: 'text', value}]
-            }
-          ];
+            child.children = [
+              {
+                // Set the @mention to bold just like GitHub/Twitter do
+                // Note that this package also puts in bold the @mentions
+                // <https://github.com/wooorm/remark-github>
+                type: 'strong',
+                children: [{type: 'text', value}]
+              }
+            ];
+          }
         } else if (isURL(value)) {
           child.type = 'link';
           child.url = value;

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ function contributorTableAttacher(opts) {
         let child;
 
         if (headers[key] && headers[key].format) {
-          child = headers[key].format(value, contrib, key);
+          child = headers[key].format(value, contrib, key, file);
 
           if (!child) {
             child = {type: 'text', value: ''};

--- a/index.js
+++ b/index.js
@@ -129,6 +129,10 @@ function contributorTableAttacher(opts) {
 
         if (headers[key] && headers[key].format) {
           child = headers[key].format(value, contrib, key);
+
+          if (!child) {
+            child = {type: 'text', value: ''};
+          }
         } else if (isURL(value)) {
           child = {type: 'link', url: value, children: [{type: 'text', value}]};
         } else {

--- a/inject.js
+++ b/inject.js
@@ -8,7 +8,9 @@ const plugin = require('./')
 fs.writeFileSync('README.md', remark().use(plugin, {
   contributors: [
     { name: 'Hugh Kennedy', github: 'hughsk', twitter: 'hughskennedy' },
-    { name: 'Titus Wormer', github: 'wooorm', twitter: 'wooorm' }
+    { name: 'Titus Wormer', github: 'wooorm', twitter: 'wooorm' },
+    { name: 'Nick Baugh', github: 'niftylettuce', twitter: 'niftylettuce' },
+    { name: 'Vincent Weevers', github: 'vweevers', twitter: 'vweevers' }
   ]
 }).processSync(
   fs.readFileSync('README.md', 'utf8')

--- a/test.js
+++ b/test.js
@@ -22,6 +22,9 @@ const packageExpected = fs.readFileSync('fixtures/package-expected.md', 'utf8');
 const customFixture = fs.readFileSync('fixtures/custom.md', 'utf8');
 const customExpected = fs.readFileSync('fixtures/custom-expected.md', 'utf8');
 
+const partialFixture = fs.readFileSync('fixtures/partial.md', 'utf8');
+const partialExpected = fs.readFileSync('fixtures/partial-expected.md', 'utf8');
+
 test('remark-contributors with package.json contributors field', t => {
   const processor = remark().use(plugin);
   const actual = processor.processSync(packageFixture).toString().trim();
@@ -69,5 +72,22 @@ test('remark-contributors with github/twitter contributors options (with typos)'
     }
   });
 
+  t.end();
+});
+
+test('remark-contributors with partial github/twitter contributors options', t => {
+  const processor = remark().use(plugin, {
+    contributors: [
+      { name: 'Sara', github: 'sara' },
+      { name: 'Jason' },
+      { name: 'Alice', twitter: 'alice' }
+    ]
+  });
+  const actual = processor.processSync(partialFixture).toString().trim();
+  const expect = partialExpected.trim();
+  t.equal(actual, expect, 'Skips missing properties');
+  if (actual !== expect) {
+    console.error(diff.diffChars(expect, actual));
+  }
   t.end();
 });


### PR DESCRIPTION
This allows for greater customization, by passing in a `headers` option:

```js
contributors({
   headers: {
     name: true, // Include default header and its formatter
     custom: {
       label: 'Custom',
       format: function (value, contrib, key) {
         // Build and return your own mdast node
       }
     }
   }
})
```

This PR looks bigger than it is; I mostly moved code around. Supersedes (builds on top of) #6.