### PR TITLE
Add required align property to table node

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,6 +202,7 @@ function contributorTableAttacher(opts) {
 
     const table = {
       type: 'table',
+      align: new Array(tableHeaders.length).fill(null),
       children: [tableHead].concat(tableRows)
     };
 


### PR DESCRIPTION
The `align` property is required according to https://github.com/syntax-tree/mdast#table:

```idl
interface Table <: Parent {
  type: "table";
  align: [alignType];
}
```

If missing it trips up plugins like `remark-lint-table-cell-padding`.

This PR doesn't change markdown output.