### PR TITLE
feature: Add option to prevent adding contribs if missing header

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ readme = remark().use(plugin, {
 
 ### Output
 
-This will add a "Contributors" section to your document if one is not already present. If one is present, a list of contributors will be added to that section.
+This will add a `Contributors` section to your document if one is not already
+present and you set [`appendIfMissing`](#options.appendIfMissing) to `true` in
+the options. If such section already is present, a list of contributors will be
+added to that section.
 
 For example, the following input markdown:
 
@@ -118,6 +121,10 @@ An array of contributors, with properties such as:
 -   `name`: the preferred name of the contributor.
 -   `github`: the GitHub account of the contributor, with or without an `@`.
 -   `twitter`: the Twitter account of the contributor, with or without an `@`.
+
+### `options.appendIfMissing`
+
+Optional. Defaults to **false**. If set to `true` it will append a section (that is, a heading and a table) if no `Contributors` heading is found.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ readme = remark().use(plugin, {
 
 ### Output
 
-This will add a `Contributors` section to your document if one is not already
-present and you set [`appendIfMissing`](#options.appendIfMissing) to `true` in
-the options. If such section already is present, a list of contributors will be
-added to that section.
+This plugin will add or update a list of contributors in a `Contributors` section.
+If such a section is not present, nothing happens by default.
+To have the plugin add a new section to the end of the document, set
+[`appendIfMissing: true`](#options.appendIfMissing).
 
 For example, the following input markdown:
 
@@ -84,7 +84,7 @@ For example, the following input markdown:
 Hello World!
 ```
 
-Would yield:
+…would not be changed, unless `appendIfMissing: true`, in which case it would yield:
 
 ```markdown
 # My Readme
@@ -99,7 +99,7 @@ Hello World!
 | **Nick Baugh**   | [**@niftylettuce**](https://github.com/niftylettuce) | [**@niftylettuce**](https://twitter.com/niftylettuce) |
 ```
 
-Any other text in the contributors section will still be preserved, so you can still include appreciative personal gratitude of your choosing.
+If there is other text in the contributors section it will be preserved: only the table will be changed.
 
 ### Notes
 

--- a/index.js
+++ b/index.js
@@ -8,8 +8,15 @@ module.exports = contributorTableAttacher;
 function contributorTableAttacher(opts) {
   opts = opts || {};
   opts.contributors = opts.contributors || [];
+  if (typeof opts.appendIfMissing === "undefined") {
+    opts.appendIfMissing = false
+  };
+
   return function contributorTableTransformer(root, file) {
     const heading = getHeadingIndex(root.children);
+    if (!heading && !opts.appendIfMissing) {
+      return;
+    }
     const children = root.children;
     let pack = {};
 

--- a/index.js
+++ b/index.js
@@ -9,10 +9,6 @@ module.exports = contributorTableAttacher;
 function contributorTableAttacher(opts) {
   opts = Object.assign({}, opts);
   opts.contributors = opts.contributors || [];
-  if (typeof opts.appendIfMissing === "undefined") {
-    opts.appendIfMissing = false
-  };
-
   let headers;
   let labels;
 

--- a/test.js
+++ b/test.js
@@ -23,10 +23,23 @@ const customFixture = fs.readFileSync('fixtures/custom.md', 'utf8');
 const customExpected = fs.readFileSync('fixtures/custom-expected.md', 'utf8');
 
 test('remark-contributors with package.json contributors field', t => {
-  const processor = remark().use(plugin);
+  const processor = remark().use(plugin, {
+    appendIfMissing: true
+  });
   const actual = processor.processSync(packageFixture).toString().trim();
   const expect = packageExpected.trim();
   t.equal(actual, expect, 'Adds section if none exists');
+  if (actual !== expect) {
+    console.error(diff.diffChars(expect, actual));
+  }
+  t.end();
+});
+
+test('do not add remark-contributors when header is missing', t => {
+  const processor = remark().use(plugin);
+  const actual = processor.processSync(packageFixture).toString().trim();
+  const expect = packageFixture.trim();
+  t.equal(actual, expect, 'Do not add section if none exists and options prevent adding');
   if (actual !== expect) {
     console.error(diff.diffChars(expect, actual));
   }
@@ -39,7 +52,8 @@ test('remark-contributors with custom contributors option headers', t => {
       { name: 'Jason', Age: 20, Commits: 99, YouTube: 'https://youtube.com/some-channel', Term: 1 },
       { Commits: 20, name: 'Alex', Term: 2 },
       { name: 'Theo', Commits: 19, Age: 17 }
-    ]
+    ],
+    appendIfMissing: true
   });
   const actual = processor.processSync(customFixture).toString().trim();
   const expect = customExpected.trim();
@@ -57,7 +71,8 @@ test('remark-contributors with github/twitter contributors options (with typos)'
         {name: 'Hugh Kennedy', GITHUB: 'hughsk', twitter: '@hughskennedy'},
         {GithuB: 'https://github.com/timoxley', name: 'Tim Oxley', TWITTER: 'secoif'},
         {Twitter: 'http://twitter.com/@rvagg/', github: 'rvagg', name: 'Rod Vagg' }
-      ]
+      ],
+      appendIfMissing: true
     });
     const actual = processor.processSync(fixtures[name]).toString().trim();
     const expect = expected[name].trim();


### PR DESCRIPTION
A new optional setting `appendIfMissing` (defaults to `true` for back compatibility) can be set to `false` to not add the contributers if such section header is missing in the readme.

Addresses https://github.com/hughsk/remark-contributors/issues/9#issuecomment-427300825