### PR TITLE
Add align option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ An array of contributors, with properties such as:
 -   `github`: the GitHub account of the contributor, with or without an `@`.
 -   `twitter`: the Twitter account of the contributor, with or without an `@`.
 
+### `options.align`
+
+Optional alignment of table cells. One of [`'left'`, `'right'`, `'center'` or `null` (default)](https://github.com/syntax-tree/mdast#aligntype).
+
 ## Contributors
 
 | Name                | GitHub                                               | Twitter                                               |

--- a/fixtures/align-expected.md
+++ b/fixtures/align-expected.md
@@ -1,0 +1,7 @@
+# Align Fixture
+
+## Contributors
+
+| Name           | Website                   |
+| :------------- | :------------------------ |
+| **Nick Baugh** | <http://niftylettuce.com> |

--- a/fixtures/align.md
+++ b/fixtures/align.md
@@ -1,0 +1,3 @@
+# Align Fixture
+
+## Contributors

--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ function contributorTableAttacher(opts) {
 
     const table = {
       type: 'table',
-      align: new Array(tableHeaders.length).fill(null),
+      align: new Array(tableHeaders.length).fill(opts.align || null),
       children: [tableHead].concat(tableRows)
     };
 

--- a/test.js
+++ b/test.js
@@ -28,6 +28,9 @@ const partialExpected = fs.readFileSync('fixtures/partial-expected.md', 'utf8');
 const formatFixture = fs.readFileSync('fixtures/format.md', 'utf8');
 const formatExpected = fs.readFileSync('fixtures/format-expected.md', 'utf8');
 
+const alignFixture = fs.readFileSync('fixtures/align.md', 'utf8');
+const alignExpected = fs.readFileSync('fixtures/align-expected.md', 'utf8');
+
 test('remark-contributors with package.json contributors field', t => {
   const processor = remark().use(plugin);
   const actual = processor.processSync(packageFixture).toString().trim();
@@ -121,6 +124,17 @@ test('remark-contributors with custom formatter options', t => {
   const actual = processor.processSync(formatFixture).toString().trim();
   const expect = formatExpected.trim();
   t.equal(actual, expect, 'Supports custom formatters');
+  if (actual !== expect) {
+    console.error(diff.diffChars(expect, actual));
+  }
+  t.end();
+});
+
+test('remark-contributors with align option', t => {
+  const processor = remark().use(plugin, { align: 'left' });
+  const actual = processor.processSync(alignFixture).toString().trim();
+  const expect = alignExpected.trim();
+  t.equal(actual, expect, 'Sets table alignment');
   if (actual !== expect) {
     console.error(diff.diffChars(expect, actual));
   }


### PR DESCRIPTION
This one line of code allows me to remove [12 lines from `remark-git-contributors`](https://github.com/vweevers/remark-git-contributors/blob/8e407926b6eba13bd0a3c177dcda24f9a536b4fe/index.js#L95-L107) (changing alignment after the fact requires traversing the tree again).