### PR TITLE
Fix case where heading is first node

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function contributorTableAttacher(opts) {
 
   return function contributorTableTransformer(root, file) {
     const heading = getHeadingIndex(root.children);
-    if (!heading && !opts.appendIfMissing) {
+    if (heading === null && !opts.appendIfMissing) {
       return;
     }
     const children = root.children;


### PR DESCRIPTION
Closes #12. I did not add a test yet, because I was thinking we should split the tests of these fixtures:

https://github.com/hughsk/remark-contributors/blob/b2e755274496c5938d497b797040fc48364329a6/test.js#L7-L11

Because only the first needs `appendIfMissing: true`. WDYT?